### PR TITLE
Fix npm run ok by restoring account types

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ The profile data is defined in `src/types/account.ts`:
 
 ```ts
 export const accountDataSchema = z.object({
-  name: z.string()
+  user: z.object({
+    name: z.string()
+  })
 })
 ```
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,5 +6,5 @@ export default function App() {
 
   if (loading) return <p>Loading...</p>
 
-  return <HomeView name={data?.name} />
+  return <HomeView name={data?.user.name} />
 }

--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,5 +1,6 @@
 import { useExists, useJson } from '@artifact/client/hooks'
 import { useEffect, useState } from 'react'
+import { accountDataSchema, type AccountData } from '../types/account.ts'
 
 const useAccountData = () => {
   const exists = useExists('profile.json')
@@ -8,13 +9,7 @@ const useAccountData = () => {
 
   useEffect(() => {
     if (raw !== undefined) {
-      if ('user' in raw) {
-        if ('name' in raw.user) {
-          setData({
-            name: raw.user.name
-          })
-        }
-      }
+      setData(accountDataSchema.parse(raw))
     }
   }, [raw])
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,9 @@ import type { AccountData } from './types/account'
 import './index.css'
 
 const mockProfile: AccountData = {
-  name: 'Jane Doe'
+  user: {
+    name: 'Jane Doe'
+  }
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const accountDataSchema = z.object({
+  user: z.object({
+    name: z.string()
+  })
+})
+
+export type AccountData = z.infer<typeof accountDataSchema>


### PR DESCRIPTION
## Summary
- restore `src/types/account.ts` with Zod schema
- parse `profile.json` with schema in `useAccountData`

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_6854a1d9dd74832b9507dafd27ec75d7